### PR TITLE
Move back to default categories

### DIFF
--- a/nodes/PineconeAssistant/PineconeAssistant.node.json
+++ b/nodes/PineconeAssistant/PineconeAssistant.node.json
@@ -2,10 +2,7 @@
 	"node": "n8n-nodes-base.pineconeAssistant",
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
-	"categories": ["AI"],
-	"subcategories": {
-		"AI": ["Miscellaneous"]
-	},
+	"categories": ["Development", "Developer Tools"],
 	"resources": {
 		"credentialDocumentation": [
 			{


### PR DESCRIPTION
Move back to default categories as search when AI categories is not working when deployed via npm
