### PR TITLE
Set RELEASE_MODE env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "dev": "n8n-node dev",
         "lint": "n8n-node lint",
         "lint:fix": "n8n-node lint --fix",
-        "release": "npx release-it",
+        "release": "RELEASE_MODE=true npx release-it",
         "prepublishOnly": "n8n-node prerelease",
         "test": "jest",
         "test:watch": "jest --watch",


### PR DESCRIPTION
Set `RELEASE_MODE` env var to true to require `npm run release` rather than `npm publish` directly. This is a hook via `n8n-node prerelease` to ensure that linting and building are executed before publishing to npm. When `RELEASE_MODE` env var is unset, `npm publish` will fail.