### PR TITLE
Move version and user agent headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ This node was tested locally against n8n 1.121.3.
 
 ## Usage
 
-Refer to our [Pinecone Assistant quickstart](https://docs.pinecone.io/guides/assistant/quickstart#n8n) for n8n to get started with a pre-built workflow using this node, an Assistant, and Open AI.
+Refer to our [Pinecone Assistant quickstart](https://docs.pinecone.io/guides/assistant/quickstart/n8n-quickstart) for n8n to get started with a pre-built workflow using this node, an Assistant, and Open AI.
 
 ## Resources
 

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -42,8 +42,6 @@ export class PineconeApi implements ICredentialType {
             properties: {
                     headers: {
                             'Api-key': '={{$credentials.apiKey}}',
-                            'X-Pinecone-API-Version': '2025-10',
-                            'User-Agent': `${packageInfo.name} v${packageInfo.version}; source_tag=${packageInfo.defaultSourceTag}:credentials`,
                     },
             },
     };
@@ -52,6 +50,10 @@ export class PineconeApi implements ICredentialType {
             request: {
                     baseURL: 'https://api.pinecone.io/assistant',
                     url: '/assistants',
+                    headers: {
+                        'X-Pinecone-API-Version': '2025-10',
+                        'User-Agent': `${packageInfo.name} v${packageInfo.version}; source_tag=${packageInfo.defaultSourceTag}:credentials`,
+                    },
             },
     };
 }


### PR DESCRIPTION
Move version and user agent headers out of `authenticate` block and into the `test` block so they are not overwritten on every request by credential headers
