### PR TITLE
Update node version in release workflow to v24

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,8 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 
       


### PR DESCRIPTION
## Summary
- Update release workflow to use Node.js 24.x (from 22)
- Add explicit npm registry URL configuration for publishing

## Test plan
- [ ] Verify release workflow runs successfully with Node.js 24.x
- [ ] Confirm npm publishing works with the registry configuration

## Related

- Recommended setup shows node 24. Node setup function bundles in npm and we need a specific and recent version of the npm CLI for the flow to work https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
- [#9812 Support OIDC publishing ("trusted publishing")](https://github.com/pnpm/pnpm/issues/9812)