### PR TITLE
Fix version.json path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Commit and tag version changes
         shell: bash
         run: |
-          git add package.json version.json CHANGELOG.md
+          git add package.json nodes/PineconeAssistant/version.json CHANGELOG.md
           newVersion="${{ steps.version-bump.outputs.version }}"
           git commit -m "[skip ci] Publish release $newVersion"
           git tag "v$newVersion"


### PR DESCRIPTION
## Problem

git add has incorrect path for version.json

## Solution

Added the path to nodes/PineconeAssistant/version.json

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

