### PR TITLE
Add version 1.2 of the node

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,14 @@ $ pnpm test
 
 5. Versioning the node
 
-When making changes to a version of the node, ensure backwards compatibility with the current version. If it cannot be backwards compatible, create a new version:
+When making changes to a version of the node, ensure backwards compatibility with the current version as all existing workflows will use the previous version until it is manually migrated. If it cannot be backwards compatible, create a new version of the node:
 
 - In `PineconeAssistant.node.ts`, change `defaultVersion` to the new version number
 - In `PineconeAssistant.node.ts`, update the list of `nodeVersions`
 - Add a new version directory, named `v#` (i.e. `v2`)
-- In the new version directory, add the versioned node, `PineconeAssistantV2.node.ts` and all all functionality.
+- In the new version directory, add the versioned node, `PineconeAssistantV2.node.ts` and all the functionality.
 
+Note: It is possible to continue using the previous version's functionality and configure per version using `displayOptions`, etc. See version 1.2.
 
 6. Release the node and publish to npm
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To use the Pinecone Assistant node, you'll need a Pinecone account and an API ke
 
 ## Compatibility
 
-This node was tested locally against n8n 1.121.3.
+This node was tested locally against n8n 2.9.4.
 
 ## Usage
 
@@ -137,7 +137,8 @@ Refer to our [Pinecone Assistant quickstart](https://docs.pinecone.io/guides/ass
 
 ## Version history
 
-- V1
+- V1 - Initial version of the Pinecone Assistant node
+- V1.2 - Deprecates the `pineconeAssistantApi` credential in favor of `pineconeApi`
 
 ## Node development
 

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -37,7 +37,7 @@ export class PineconeApi implements ICredentialType {
             },
             {
                 displayName:
-                        "Start building with the Pinecone Assistant node before March 31, 2026 to receive a discount when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
+                        "Start building with the Pinecone Assistant node before May 1, 2026 to receive a discount when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
                 name: 'notice',
                 type: 'notice',
                 default: '',

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -10,7 +10,8 @@ import * as packageInfo from '../nodes/PineconeAssistant/version.json';
 export class PineconeApi implements ICredentialType {
     name = 'pineconeAssistantApi';
 
-    displayName = 'Pinecone Assistant API';
+    // eslint-disable-next-line n8n-nodes-base/cred-class-field-display-name-missing-api
+    displayName = 'Pinecone Assistant API - DEPRECATED';
 
     icon = {
             light: 'file:../nodes/PineconeAssistant/pinecone.svg',
@@ -28,19 +29,22 @@ export class PineconeApi implements ICredentialType {
                 default: '',
             },
             {
-                    displayName: 'API Key',
-                    name: 'apiKey',
-                    type: 'string',
-                    typeOptions: { password: true },
-                    required: true,
-                    default: '',
+                displayName: 'API Key',
+                name: 'apiKey',
+                type: 'string',
+                typeOptions: { password: true },
+                required: true,
+                default: '',
             },
             {
                 displayName:
-                        "Start building with the Pinecone Assistant node before May 1, 2026 to receive a discount when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
+                        "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
                 name: 'notice',
                 type: 'notice',
                 default: '',
+                displayOptions: {
+                        hideOnCloud: true
+                }
             },
     ];
 

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -38,7 +38,7 @@ export class PineconeApi implements ICredentialType {
             },
             {
                 displayName:
-                        "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
+                        "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
                 name: 'notice',
                 type: 'notice',
                 default: '',

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -24,7 +24,7 @@ export class PineconeApi implements ICredentialType {
             {
                 displayName:
                         "This credential type is deprecated. Please update to the latest version of the Pinecone Assistant node.",
-                name: 'notice',
+                name: 'deprecationNotice',
                 type: 'notice',
                 default: '',
             },
@@ -39,7 +39,7 @@ export class PineconeApi implements ICredentialType {
             {
                 displayName:
                         "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
-                name: 'notice',
+                name: 'promoNotice',
                 type: 'notice',
                 default: '',
                 displayOptions: {

--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -21,6 +21,13 @@ export class PineconeApi implements ICredentialType {
 
     properties: INodeProperties[] = [
             {
+                displayName:
+                        "This credential type is deprecated. Please update to the latest version of the Pinecone Assistant node.",
+                name: 'notice',
+                type: 'notice',
+                default: '',
+            },
+            {
                     displayName: 'API Key',
                     name: 'apiKey',
                     type: 'string',

--- a/nodes/PineconeAssistant/PineconeAssistant.node.ts
+++ b/nodes/PineconeAssistant/PineconeAssistant.node.ts
@@ -12,11 +12,12 @@ export class PineconeAssistant extends VersionedNodeType {
 			group: ['transform'],
 			subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
 			description: 'A Pinecone Assistant node for n8n',
-			defaultVersion: 1,
+			defaultVersion: 1.2,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
 			1: new PineconeAssistantV1(baseDescription),
+			1.2: new PineconeAssistantV1(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/nodes/PineconeAssistant/v1/actions/versionDescription.ts
+++ b/nodes/PineconeAssistant/v1/actions/versionDescription.ts
@@ -59,7 +59,7 @@ export const versionDescription: INodeTypeDescription = {
         {
             // eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
             displayName:
-                    "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
+                    "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
             name: 'callout',
             type: 'callout',
             default: '',

--- a/nodes/PineconeAssistant/v1/actions/versionDescription.ts
+++ b/nodes/PineconeAssistant/v1/actions/versionDescription.ts
@@ -14,7 +14,7 @@ export const versionDescription: INodeTypeDescription = {
     displayName: 'Pinecone Assistant',
     name: 'pineconeAssistant',
     group: ['transform'],
-    version: 1,
+    version: [1, 1.2],
     description: 'A Pinecone Assistant node for n8n',
     defaults: {
         name: 'Pinecone Assistant',
@@ -25,10 +25,35 @@ export const versionDescription: INodeTypeDescription = {
         {
             name: 'pineconeAssistantApi',
             required: true,
+            displayOptions: {
+                show: {
+                    '@version': [1]
+                }
+            }
+        },
+        {
+            name: 'pineconeApi',
+            required: true,
+            displayOptions: {
+                show: {
+                    '@version': [1.2]
+                }
+            }
         },
     ],
     subtitle: '={{ $parameter["operation"] + ": " + $parameter["resource"] }}',
     properties: [
+        {
+            displayName: '<strong>New node version available:</strong> get the latest version with added features from the nodes panel.',
+            name: 'oldVersionNotice',
+            type: 'notice',
+            default: '',
+            displayOptions: {
+                show: {
+                    '@version': [1]
+                }
+            }
+        },
         // Resources
         {
             displayName: 'Resource',

--- a/nodes/PineconeAssistant/v1/actions/versionDescription.ts
+++ b/nodes/PineconeAssistant/v1/actions/versionDescription.ts
@@ -23,6 +23,7 @@ export const versionDescription: INodeTypeDescription = {
     outputs: [NodeConnectionTypes.Main],
     credentials: [
         {
+            displayName: 'Credential to connect with',
             name: 'pineconeAssistantApi',
             required: true,
             displayOptions: {
@@ -32,6 +33,7 @@ export const versionDescription: INodeTypeDescription = {
             }
         },
         {
+            displayName: 'Credential to connect with',
             name: 'pineconeApi',
             required: true,
             displayOptions: {
@@ -52,6 +54,17 @@ export const versionDescription: INodeTypeDescription = {
                 show: {
                     '@version': [1]
                 }
+            }
+        },
+        {
+            // eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+            displayName:
+                    "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node'>here<a/>.",
+            name: 'callout',
+            type: 'callout',
+            default: '',
+            displayOptions: {
+                hideOnCloud: true
             }
         },
         // Resources

--- a/nodes/PineconeAssistant/v1/genericFunctions.test.ts
+++ b/nodes/PineconeAssistant/v1/genericFunctions.test.ts
@@ -73,6 +73,7 @@ describe('genericFunctions', () => {
 			logger: {
 				debug: jest.fn(),
 			},
+			getNode: () => ({ typeVersion: 1.2 }),
 		} as unknown as jest.Mocked<IExecuteFunctions>;
 	});
 
@@ -100,7 +101,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'GET',
 					url: `${baseUrl}/assistant/${endpoint}`,
@@ -114,6 +115,30 @@ describe('genericFunctions', () => {
 			);
 			expect(mockHttpRequest.mock.calls[0][1]).not.toHaveProperty('body');
 			expect(result).toEqual(mockResponse);
+		});
+
+		it('should use pineconeAssistantApi when node version is 1', async () => {
+			// Arrange: override getNode to return version 1
+			const mockWithVersion1 = {
+				...mockExecuteFunctions,
+				getNode: () => ({ typeVersion: 1 }),
+			} as jest.Mocked<IExecuteFunctions>;
+			const method = 'GET';
+			const baseUrl = 'https://api.pinecone.io';
+			const endpoint = 'assistants';
+			const body = {};
+			const mockResponse = { assistants: [] };
+
+			mockHttpRequest.mockResolvedValue(mockResponse);
+
+			// Act
+			await apiRequest.call(mockWithVersion1, method, baseUrl, endpoint, body);
+
+			// Assert
+			expect(mockHttpRequest).toHaveBeenCalledWith(
+				'pineconeAssistantApi',
+				expect.anything(),
+			);
 		});
 
 		it('should make a POST request with JSON body', async () => {
@@ -137,7 +162,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'POST',
 					url: `${baseUrl}/assistant/${endpoint}`,
@@ -183,7 +208,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'POST',
 					url: `${baseUrl}/assistant/${endpoint}`,
@@ -313,7 +338,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					qs: {},
 				}),
@@ -362,7 +387,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					headers: {
 						'X-Pinecone-API-Version': '2025-10',
@@ -396,7 +421,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					headers: {
 						'X-Pinecone-API-Version': '2025-10',
@@ -429,7 +454,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					headers: {
 						'X-Pinecone-API-Version': '2025-10',
@@ -463,7 +488,7 @@ describe('genericFunctions', () => {
 
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'GET',
 					url: `${assistantHostUrl}/assistant/files/${assistantName}`,
@@ -701,6 +726,7 @@ describe('genericFunctions', () => {
 				logger: {
 					debug: jest.fn(),
 				},
+				getNode: () => ({ typeVersion: 1.2 }),
 			} as unknown as jest.Mocked<IExecuteFunctions>;
 		});
 
@@ -738,7 +764,7 @@ describe('genericFunctions', () => {
 			expect(mockExecuteFunctionsForUpload.helpers.assertBinaryData).toHaveBeenCalledWith(index, inputDataFieldName);
 			expect(mockExecuteFunctionsForUpload.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(index, inputDataFieldName);
 			expect(mockHttpRequestForUpload).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'POST',
 					url: expect.stringContaining('files/test-assistant?metadata='),
@@ -1121,7 +1147,7 @@ describe('genericFunctions', () => {
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledTimes(1);
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'DELETE',
 					url: `${assistantHostUrl}/assistant/files/${assistantName}/${fileIds[0]}`,
@@ -1146,21 +1172,21 @@ describe('genericFunctions', () => {
 			// Assert
 			expect(mockHttpRequest).toHaveBeenCalledTimes(3);
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'DELETE',
 					url: `${assistantHostUrl}/assistant/files/${assistantName}/file-456`,
 				}),
 			);
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'DELETE',
 					url: `${assistantHostUrl}/assistant/files/${assistantName}/file-789`,
 				}),
 			);
 			expect(mockHttpRequest).toHaveBeenCalledWith(
-				'pineconeAssistantApi',
+				'pineconeApi',
 				expect.objectContaining({
 					method: 'DELETE',
 					url: `${assistantHostUrl}/assistant/files/${assistantName}/file-101`,

--- a/nodes/PineconeAssistant/v1/genericFunctions.ts
+++ b/nodes/PineconeAssistant/v1/genericFunctions.ts
@@ -72,6 +72,22 @@ function hasFileData(body: object): boolean {
 }
 
 /**
+ * Resolve which credential name the node uses for the current context (by node version).
+ * Version 1 uses the deprecated pineconeAssistantApi.
+ * Version 1.2 uses pineconeApi.
+ */
+function getCredentialNameForContext(
+	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
+): 'pineconeAssistantApi' | 'pineconeApi' {
+	const node = 'getNode' in this ? this.getNode() : null;
+	const version = node?.typeVersion;
+	if (version === 1) {
+		return 'pineconeAssistantApi';
+	}
+	return 'pineconeApi';
+}
+
+/**
  * Make an API request to Pinecone Assistant
  */
 export async function apiRequest(
@@ -108,7 +124,8 @@ export async function apiRequest(
         delete options.body;
 	}
 
-	return await this.helpers.httpRequestWithAuthentication.call(this, 'pineconeAssistantApi', options);
+	const credentialName = getCredentialNameForContext.call(this);
+	return await this.helpers.httpRequestWithAuthentication.call(this, credentialName, options);
 }
 
 export async function getFiles(this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions, assistantName: string, assistantHostUrl: string, filterValues: IDataObject | null | undefined, sourceTag?: string) {


### PR DESCRIPTION
## Problem

Add version 1.2 of the node to deprecate the pineconeAssistantApi credential and use pineconeApi for better discoverability and to support Quick Connect. Updating promo copy.

## Solution

- Added new version info and inspected the node version at runtime to make sure the right version is selected when making the api call
- Add deprecation banner on the node to push people to update their node for both Cloud and self-hosted users (this is standard practice with nodes)
- Show DEPRECATED in credential name for credential select list
- Update the promo banner on the credential for self-hosted only; remove promo banner for Cloud as Quick Connect will cover this
- Show the promo banner on the node for self-hosted only (Quick Connect handles the Cloud promo banner) so that our original offer still stands and applies to anyone not just Cloud users.
- Change displayName for credential in versionDescription so it matches previous version (where there was only 1 credential in config)
- Updated the promo copy to extend the offer

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Updated unit tests; tested locally and in a docker container; cannot be tested on n8n cloud until it's released

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which credential is used for authenticated HTTP requests based on node version; mis-detection or missing `pineconeApi` setup could break API calls, though v1 remains supported as a fallback.
> 
> **Overview**
> Updates the Pinecone Assistant node to **default to version 1.2** while keeping version 1 available, and wires the node UI to require `pineconeAssistantApi` only for v1 and `pineconeApi` for v1.2 (including an in-node notice encouraging users to upgrade).
> 
> Adds runtime logic in `apiRequest` to choose the credential name based on `typeVersion`, updates unit tests accordingly, and refreshes README/version history and promotional/deprecation notices (including cloud-vs-self-hosted display options and updated offer copy).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06bd5ab4a18d59c72a269d54033802a430ab07d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->