### PR TITLE
Pinecone credential property names

### DIFF
--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -24,7 +24,7 @@ export class PineconeApi implements ICredentialType {
             {
                 displayName:
                         "This credential type is deprecated. Please update to the latest version of the Pinecone Assistant node.",
-                name: 'notice',
+                name: 'deprecationNotice',
                 type: 'notice',
                 default: '',
             },
@@ -39,7 +39,7 @@ export class PineconeApi implements ICredentialType {
             {
                 displayName:
                         "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
-                name: 'notice',
+                name: 'promoNotice',
                 type: 'notice',
                 default: '',
                 displayOptions: {


### PR DESCRIPTION
Rename duplicate `notice` properties in PineconeApi credentials to prevent potential UI interference issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes internal property identifiers for credential notices; no auth logic or API behavior changes, but could affect any code referencing the old `notice` key.
> 
> **Overview**
> Updates `credentials/PineconeApi.credentials.ts` to rename the two `notice`-type properties from the duplicate `name: 'notice'` to distinct keys (`deprecationNotice` and `promoNotice`), preventing potential credential UI interference while keeping behavior and messaging the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f548184e09f6aef3f84e42b9d9d9be9ae15e7c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->