### PR TITLE
Add GitHub bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: debug-info
     attributes:
       label: Debug info

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a bug with the Pinecone Assistant n8n node
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe what happened and what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Configure the node with...
+        2. Run the workflow...
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: n8n-deployment
+    attributes:
+      label: n8n Deployment Type
+      description: How are you running n8n?
+      options:
+        - n8n Cloud
+        - Self-hosted
+    validations:
+      required: true
+
+  - type: input
+    id: n8n-version
+    attributes:
+      label: n8n Version
+      description: What version of n8n are you running? (e.g. 2.16.2)
+      placeholder: "2.16.2"
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node Version
+      description: What version of the Pinecone Assistant node are you using? (Check your installed community nodes)
+      placeholder: "0.1.10"
+    validations:
+      required: true
+
+  - type: input
+    id: debug-info
+    attributes:
+      label: Debug info
+      description: This can be found under Help > About n8n > Copy debug information
+      placeholder: "# Debug info..."
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Adds a structured GitHub issue template for bug reports
- Collects key n8n environment info: deployment type (Cloud vs Self-hosted), n8n version, Pinecone Assistant node version, and n8n debug info
- Uses n8n's built-in "Help > About n8n > Copy debug information" to capture Node.js version, OS, and other env details in one field

Closes [DR-356](https://linear.app/pinecone-io/issue/DR-356/create-github-issue-template)

## Test plan
- [ ] Open a new issue on GitHub and verify the template appears and all fields render correctly
- [ ] Confirm required fields block submission when empty

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only change that affects GitHub issue creation, not runtime code or shipped artifacts.
> 
> **Overview**
> Adds a GitHub **bug report** issue template (`.github/ISSUE_TEMPLATE/bug_report.yml`) for the Pinecone Assistant n8n node.
> 
> The template standardizes required fields for bug description, repro steps, expected behavior, n8n deployment type/version, node version, and pasted n8n debug info to improve triage quality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1050fe7a2b5191fdd48f676d68f08a56861a6d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->