### PR TITLE
Remove expired promo banner from node and credential

### DIFF
--- a/credentials/PineconeApi.credentials.ts
+++ b/credentials/PineconeApi.credentials.ts
@@ -36,16 +36,6 @@ export class PineconeApi implements ICredentialType {
                 required: true,
                 default: '',
             },
-            {
-                displayName:
-                        "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
-                name: 'promoNotice',
-                type: 'notice',
-                default: '',
-                displayOptions: {
-                        hideOnCloud: true
-                }
-            },
     ];
 
     authenticate: IAuthenticateGeneric = {

--- a/nodes/PineconeAssistant/v1/actions/versionDescription.ts
+++ b/nodes/PineconeAssistant/v1/actions/versionDescription.ts
@@ -56,17 +56,6 @@ export const versionDescription: INodeTypeDescription = {
                 }
             }
         },
-        {
-            // eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
-            displayName:
-                    "Start building with Pinecone before May 1, 2026 to receive platform credits when upgrading to Pinecone's Standard plan. Learn more and claim this offer <a href='https://app.pinecone.io/?integration=pinecone-n8n-assistant-node' target='_blank' rel='noopener noreferrer'>here</a>.",
-            name: 'callout',
-            type: 'callout',
-            default: '',
-            displayOptions: {
-                hideOnCloud: true
-            }
-        },
         // Resources
         {
             displayName: 'Resource',


### PR DESCRIPTION
## Summary

- Removes the expired May 1, 2026 promotional banner callout from the node (`versionDescription.ts`)
- Removes the matching `promoNotice` from the deprecated credential (`PineconeApi.credentials.ts`)

Closes DR-917

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes UI-only promotional `notice`/`callout` fields from the node and deprecated credential, with no impact to authentication or API behavior.
> 
> **Overview**
> Removes the expired Pinecone promotional banner from both the deprecated `PineconeApi.credentials.ts` credential (`promoNotice`) and the v1 node `versionDescription.ts` (`callout`).
> 
> No functional changes to request/authentication logic; this is purely a UI/UX cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fbf0f3bbc6ef3fc1466a721b297bd0a93f069c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->